### PR TITLE
v0.4.15-cs1.3.1

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,12 +19,6 @@ builds:
     ldflags:
       - -X main.commit={{.Commit}}
       - -X main.date={{.Date}}
-      - -X github.com/BeesNestInc/CasaOS/drivers/google_drive.client_id={{.Env.GoogleID}}
-      - -X github.com/BeesNestInc/CasaOS/drivers/google_drive.client_secret={{.Env.GoogleSecret}}
-      - -X github.com/BeesNestInc/CasaOS/drivers/onedrive.client_id={{.Env.OneDriveID}}
-      - -X github.com/BeesNestInc/CasaOS/drivers/onedrive.client_secret={{.Env.OneDriveSecret}}
-      - -X github.com/BeesNestInc/CasaOS/drivers/dropbox.app_key={{.Env.DropboxKey}}
-      - -X github.com/BeesNestInc/CasaOS/drivers/dropbox.app_secret={{.Env.DropboxSecret}}
       - -s
       - -w
       - -extldflags "-static"
@@ -47,12 +41,6 @@ builds:
       - -X main.commit={{.Commit}}
       - -X main.date={{.Date}}
       - -X main.Version={{.Version}} 
-      - -X github.com/BeesNestInc/CasaOS/drivers/google_drive.client_id={{.Env.GoogleID}}
-      - -X github.com/BeesNestInc/CasaOS/drivers/google_drive.client_secret={{.Env.GoogleSecret}}
-      - -X github.com/BeesNestInc/CasaOS/drivers/onedrive.client_id={{.Env.OneDriveID}}
-      - -X github.com/BeesNestInc/CasaOS/drivers/onedrive.client_secret={{.Env.OneDriveSecret}}
-      - -X github.com/BeesNestInc/CasaOS/drivers/dropbox.app_key={{.Env.DropboxKey}}
-      - -X github.com/BeesNestInc/CasaOS/drivers/dropbox.app_secret={{.Env.DropboxSecret}}
       - -s
       - -w
       - -extldflags "-static"
@@ -75,12 +63,6 @@ builds:
       - -X main.commit={{.Commit}}
       - -X main.date={{.Date}}
       - -X main.Version={{.Version}} 
-      - -X github.com/BeesNestInc/CasaOS/drivers/google_drive.client_id={{.Env.GoogleID}}
-      - -X github.com/BeesNestInc/CasaOS/drivers/google_drive.client_secret={{.Env.GoogleSecret}}
-      - -X github.com/BeesNestInc/CasaOS/drivers/onedrive.client_id={{.Env.OneDriveID}}
-      - -X github.com/BeesNestInc/CasaOS/drivers/onedrive.client_secret={{.Env.OneDriveSecret}}
-      - -X github.com/BeesNestInc/CasaOS/drivers/dropbox.app_key={{.Env.DropboxKey}}
-      - -X github.com/BeesNestInc/CasaOS/drivers/dropbox.app_secret={{.Env.DropboxSecret}}
       - -s
       - -w
       - -extldflags "-static"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## []
+
+### 修正
+- goreleaserから使用しないクラウドドライブのための関連のビルド時フラグを削除
+- クラウドドライブ関連のコードはまだ残っている状態
+
 ## [v0.4.15-cs1.3.0]
 
 ### 変更


### PR DESCRIPTION
### 修正
- goreleaserから使用しないクラウドドライブのための関連のビルド時フラグを削除
- クラウドドライブ関連のコードはまだ残っている状態