### PR TITLE
v0.4.15-cs1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [Unreleased]
+### Changed
+- OpenAPI上のWiFiAPIの定義で使用している`client`がほかのリポジトリと衝突していたため`wifi-client`に修正した
+
 ## [v0.4.15-cs1.3.1]
 
 ### 修正

--- a/api/cassetteos/openapi.yaml
+++ b/api/cassetteos/openapi.yaml
@@ -376,7 +376,7 @@ components:
         mode:
           type: string
           description: WiFi mode to switch to
-          enum: [client, ap]
+          enum: [wifi-client, ap]
         ssid:
           type: string
           description: SSID to connect to (only in client mode)

--- a/build/sysroot/usr/share/cassetteos/shell/setup-wifi-client.sh
+++ b/build/sysroot/usr/share/cassetteos/shell/setup-wifi-client.sh
@@ -5,7 +5,7 @@ set +a
 
 INTERFACE=$(iw dev | awk '$1=="Interface"{print $2}')
 WPA_CONF_PATH="/etc/wpa_supplicant/wpa_supplicant-${INTERFACE}.conf"
-WPA_TEMPLATE="/etc/cassetteos/wifi/templates/wpa_supplicant.conf.template"
+WPA_TEMPLATE="/etc/cassetteos/wifi/wpa_supplicant.conf.template"
 NETWORK_TEMPLATE="/etc/cassetteos/wifi/network/10-wifi.network.template"
 NETWORK_TARGET="/etc/systemd/network/10-wifi.network"
 RESOLV_SOURCE="/etc/cassetteos/wifi/resolv/resolv-client.conf"


### PR DESCRIPTION
- OpenAPI上のWiFiAPIの定義で使用している`client`がほかのリポジトリと衝突していたため`wifi-client`に修正した
